### PR TITLE
fix: RBAC Roles field with empty label by default

### DIFF
--- a/src/main/resources/qip-model/element/properties/access-control-properties.schema.yaml
+++ b/src/main/resources/qip-model/element/properties/access-control-properties.schema.yaml
@@ -22,7 +22,7 @@ allOf:
         roles:
           title: Roles
           type: array
-          minItems: 1
+          minItems: 0
           items:
             type: string
       required:


### PR DESCRIPTION
Close #82 