### PR TITLE
feat: add skip empty query parameters option to service-call schema

### DIFF
--- a/src/main/resources/qip-model/element/service-call.schema.yaml
+++ b/src/main/resources/qip-model/element/service-call.schema.yaml
@@ -64,6 +64,12 @@ properties:
           type: array
           items:
             $ref: "#/definitions/ResponseValidation"
+        integrationOperationSkipEmptyQueryParameters:
+          type: boolean
+          default: false
+          title: Skip empty query parameters
+          description: >
+            If checked, empty query parameters will be excluded from the request URL.
 definitions:
   AuthorizationInherit:
     title: Inherit


### PR DESCRIPTION
Add integrationOperationSkipEmptyQueryParameters property to service-call schema to allow excluding empty query parameters from HTTP request URLs. The property defaults to false to maintain backward compatibility.