### PR TITLE
fix(schema): enforce 255-char limit on common element name/description (#126)

### DIFF
--- a/src/main/resources/qip-model/element/properties/common-element-properties.schema.yaml
+++ b/src/main/resources/qip-model/element/properties/common-element-properties.schema.yaml
@@ -10,9 +10,11 @@ properties:
   name:
     type: string
     title: Name
+    maxLength: 255
   description:
     type: string
     title: Description
+    maxLength: 255
   swimlaneId:
     type: string
     title: Swimlane Identifier


### PR DESCRIPTION
**Summary**
Adds maxLength: 255 to name and description in the shared common element properties fragment so JSON Schema validation (AJV / consumers) rejects values longer than 255 characters, consistent with platform limits.

**Problem**
Element name / description were unconstrained in common-element-properties.schema.yaml, so schema-driven clients did not show length validation before save.

**Solution**
src/main/resources/qip-model/element/properties/common-element-properties.schema.yaml: maxLength: 255 on name and description.